### PR TITLE
[Feat] in-line url 이미지 처리

### DIFF
--- a/gmail_api/gmail_process.py
+++ b/gmail_api/gmail_process.py
@@ -7,7 +7,7 @@ from google_auth_oauthlib.flow import InstalledAppFlow
 from googleapiclient.discovery import build
 
 from .document_parse import parse_document
-from .utils import decode_base64, delete_file, replace_image_patten_with, save_file
+from .utils import decode_base64, delete_file, replace_image_pattern_with, replace_url_pattern_from, save_file
 
 # 이 스코프를 수정하면 token.json 파일을 삭제해야 합니다.
 SCOPES = ["https://www.googleapis.com/auth/gmail.readonly"]
@@ -133,8 +133,8 @@ class MessageHandler:
         """
         payload = message.get("payload", {})
         body, filenames = MessageHandler.process_message_part(service, message["id"], payload)
-        replaced_body, attachments = replace_image_patten_with(body, filenames)
-
+        replaced_body, attachments = replace_image_pattern_with(body, filenames)
+        replaced_body = replace_url_pattern_from(replaced_body)
         return replaced_body, attachments
 
     @staticmethod

--- a/gmail_api/utils.py
+++ b/gmail_api/utils.py
@@ -2,6 +2,11 @@ import base64
 import os
 import re
 from collections import deque
+from typing import Optional
+
+import requests
+
+from .document_parse import parse_document
 
 
 def decode_base64(data: str) -> bytes:
@@ -17,15 +22,15 @@ def decode_base64(data: str) -> bytes:
     return base64.b64decode(data)
 
 
-def save_file(file_data: str, file_name: str = "attachment", save_dir: str = "downloaded_files") -> None:
+def save_file(file_data: bytes, file_name: str, save_dir: str = "downloaded_files") -> Optional[str]:
     """
     파일 데이터를 정해진 경로에 저장합니다.
 
     인자:
         file_data (str): 저장할 파일 정보.
-        file_path (str): 저장할 파일 이름름.
+        file_path (str): 저장할 파일 이름.
     반환값:
-        file_path (str): 파일을 저장한 경로.
+        Optional[str]: 파일을 저장 성공시 저장 경로, 실패 시 None.
     """
     try:
         os.makedirs(save_dir, exist_ok=True)
@@ -59,26 +64,84 @@ def delete_file(saved_file_path: str) -> bool:
         return False
 
 
-def replace_image_patten_with(plain_text: str, files: deque) -> str:
+def replace_image_pattern_with(plain_text: str, files: deque) -> str:
     """
-    `plain_text` 내 `[image: ]` 패턴을 찾아 `files` 리스트의 leftpop 값으로 대체합니다.
+    `[image: ]` 패턴을 deque에서 가져온 값으로 대체합니다.
 
-    인자:
-        plain_text (str): 대체가 필요한 텍스트.
-        files (deque): 대체할 파일 내용을 포함한 deque.
-    반환값:
-        updated_text (str): 대체가 완료된 텍스트.
-        files (deque): 대체된 뒤 남은 파일 내용을 포함한 deque.
+    Args:
+        plain_text (str): 패턴을 대체할 텍스트.
+        files (deque): 대체할 파일 내용이 저장된 deque.
+
+    Returns:
+        str: 패턴이 대체된 텍스트.
     """
-    matches = list(re.finditer(r"\[image: (.+?)\]", plain_text))
-
-    if not matches:
-        return plain_text, files
 
     def replacement(match):
-        # files에서 첫번째 요소를 반환하거나, files가 비어있을 경우 원문을 그대로 반환한다.
+        # files에서 첫 번째 요소를 반환하거나, files가 비어있을 경우 원문을 그대로 반환
         return files.popleft() if files else match.group(0)
 
     updated_text = re.sub(r"\[image: (.+?)\]", replacement, plain_text)
-
     return updated_text, files
+
+
+def replace_pattern_with(parsed_items: dict, text: str, pattern: str) -> str:
+    """
+    텍스트에서 주어진 패턴을 찾아, 매칭된 항목을 파싱된 값으로 대체합니다.
+
+    인자:
+        parsed_items (dict): 패턴 매칭값과 대체값의 매핑 딕셔너리.
+        text (str): 패턴을 대체할 텍스트.
+        pattern (str): 대체할 패턴.
+
+    반환값:
+        str: 대체가 완료된 텍스트.
+    """
+
+    def replacement(match):
+        key = match.group(1)
+        return parsed_items.get(key, match.group(0))  # 매칭된 키가 없으면 원본 유지
+
+    return re.sub(pattern, replacement, text)
+
+
+def replace_url_pattern_from(plain_text):
+    """
+    텍스트에서 URL 패턴을 추출하고 이미지를 다운로드하여 저장한 뒤,
+    URL 패턴을 대체된 값으로 업데이트합니다.
+
+    인자:
+        plain_text (str): URL을 포함한 텍스트.
+        save_dir (str): 이미지를 저장할 디렉토리 경로.
+    반환값:
+        str: URL 패턴이 대체된 텍스트.
+    """
+    url_pattern = r"\[([^\]]+)\]"
+    urls = re.findall(url_pattern, plain_text)
+    url_to_parsed_image = {}
+
+    for url in urls:
+        try:
+            # URL에 요청을 보내 해당 content의 타입을 확인
+            response = requests.get(url, stream=True, timeout=10)
+            content_type = response.headers.get("Content-Type", "")
+
+            if "image" in content_type:
+                file_extension = content_type.split("/")[-1].split(";")[0]
+                file_name = url.split("/")[-1].split("?")[0]
+
+                if not file_name.endswith(file_extension):
+                    file_name += f".{file_extension}"
+
+                file_data = response.content
+                file_path = save_file(file_data, file_name)
+
+                if file_path:
+                    parsed_image = parse_document(file_path)
+                    url_to_parsed_image[url] = parsed_image
+                    delete_file(file_path)
+            else:
+                print(f"URL is not an image: {url}")
+        except Exception as e:
+            print(f"Failed to process {url}: {e}")
+
+    return replace_pattern_with(url_to_parsed_image, plain_text, url_pattern)


### PR DESCRIPTION


## 📝 Summary
기존에 처리해 둔 [image: ] 형태 외 
[url] 형식으로 첨부된 in-line 이미지를 파싱하여 plain text로 대체합니다.
<!--
PR의 주요 내용을 간단히 요약해주세요.
예: 로그인 기능에서 사용자 세션 관리 개선.
-->

## ✅ Checklist

<!--
해당되는 항목을 [x]로 만들어주세요.
예: - [x] 관련 이슈가 명시되어 있습니다.

해당되지 않는 항목은 앞뒤로 ~를 붙여서 취소선을 그어주세요.
예: - ~[ ] 관련 이슈가 명시되어 있습니다.~
-->

- [x] 관련 이슈가 명시되어 있습니다.
~- [ ] 테스트가 완료되었습니다.~
~- [ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

mail에서 추출한 body는 두 차례의 대체 작업을 진행합니다.
```
replaced_body, attachments = replace_image_pattern_with(body, filenames)
replaced_body = replace_url_pattern_from(replaced_body)
```
1. replace_image_pattern_with()
  기존에 진행하던 작업
  MessagePart를 처리하며 얻은 filenames 활용한 대체
  
2. replace_url_pattern_from()
  신규 추가된 작업
  filenames에 검출되지 않은 url 패턴의 in-line 이미지 대체
    - 대괄호 패턴(`[ ]`)을 전부 검사하여, 대괄호 내에 url이 작성되어 있는지 확인합니다.
    url이 아닌 예: [학과 소식지 발송]  

    - 해당 url이 이미지 content인지 확인 합니다.
    이미지 content가 아닌 url의 예: [yce9110@gmail.com]  

    - 이미지를 파싱하여 plain text로 대체합니다.

<!--
PR의 변경 사항을 구체적으로 설명해주세요.
예: 이번 변경 사항에는 로그인 세션 시간 연장 및 오류 메시지 개선이 포함됩니다.
-->

## 💡 Notice (Optional)
현재 
1. 대괄호 내 텍스트가 url이 아닌 경우 
2. url이 이미지 content가 아닌 경우
error message를 print 합니다.
<img width="892" alt="image" src="https://github.com/user-attachments/assets/0c555dcf-67a5-40eb-ba30-2e1e0adc3964" />

<!--
리뷰어가 알아야 할 추가적인 사항이나 주의점이 있다면 작성해주세요.
예: 이 기능은 인증 모듈과 호환성을 고려해야 합니다.
-->

## 🔗 Related Issue(s)
#9 
<!--
이 PR과 관련된 이슈나 기존 PR이 있다면 번호를 언급하고, 필요 시 close할 이슈도 명시해주세요.
예: 관련 이슈 - #33, close #27
-->
