### PR TITLE
[Fix] tsconfig import 규칙 수정

### DIFF
--- a/chrome-extension/src/app/App.tsx
+++ b/chrome-extension/src/app/App.tsx
@@ -1,8 +1,8 @@
 import { Suspense } from "react"
 import { RecoilRoot } from "recoil"
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query"
-import Content from "@/app/Content.tsx"
-import Toast from "@/components/toast/Toast.tsx"
+import Content from "@/app/Content"
+import Toast from "@/components/toast/Toast"
 
 function App() {
   const queryClient = new QueryClient()

--- a/chrome-extension/src/app/Content.tsx
+++ b/chrome-extension/src/app/Content.tsx
@@ -1,9 +1,9 @@
 import { useEffect } from "react"
 import { useRecoilValue, useSetRecoilState } from "recoil"
-import GoogleLoginBtn from "@/containers/auth/GoogleLogin.tsx"
-import { isLoginState, userIdState } from "@/states/auth.ts"
-import UserInfo from "@/containers/profile/UserInfo.tsx"
-import useUserLoginInfoQuery from "@/hooks/useUserLoginInfoQuery.ts"
+import GoogleLoginBtn from "@/containers/auth/GoogleLogin"
+import { isLoginState, userIdState } from "@/states/auth"
+import UserInfo from "@/containers/profile/UserInfo"
+import useUserLoginInfoQuery from "@/hooks/useUserLoginInfoQuery"
 
 function Content() {
   const setUserId = useSetRecoilState(userIdState)

--- a/chrome-extension/src/components/toast/Toast.tsx
+++ b/chrome-extension/src/components/toast/Toast.tsx
@@ -1,9 +1,7 @@
-"use client"
-
 import { MdCheckCircleOutline, MdErrorOutline, MdWarningAmber } from "react-icons/md"
 import { useRecoilValue } from "recoil"
-import { ToastData } from "@/types/toast"
 import toastState from "@/states/toastState"
+import { ToastData } from "@/types/toast"
 import ToastItem from "@/components/toast/ToastItem"
 
 function Toast(): JSX.Element {

--- a/chrome-extension/src/components/toast/ToastItem.tsx
+++ b/chrome-extension/src/components/toast/ToastItem.tsx
@@ -1,8 +1,6 @@
-"use client"
-
-import { ToastData } from "@/types/toast"
 import React, { useEffect, useState } from "react"
 import { useSetRecoilState } from "recoil"
+import { ToastData } from "@/types/toast"
 import toastState from "@/states/toastState"
 
 interface Props {

--- a/chrome-extension/src/containers/auth/GoogleLogin.tsx
+++ b/chrome-extension/src/containers/auth/GoogleLogin.tsx
@@ -1,8 +1,8 @@
 import { useSetRecoilState } from "recoil"
 import { useMutation } from "@tanstack/react-query"
-import axiosInstance from "@/utils/axiosInstance.ts"
-import { userIdState } from "@/states/auth.ts"
-import useToast from "@/hooks/useToast.ts"
+import axiosInstance from "@/utils/axiosInstance"
+import { userIdState } from "@/states/auth"
+import useToast from "@/hooks/useToast"
 
 export default function GoogleLoginBtn() {
   const setUserId = useSetRecoilState(userIdState)

--- a/chrome-extension/src/containers/profile/UserInfo.tsx
+++ b/chrome-extension/src/containers/profile/UserInfo.tsx
@@ -1,9 +1,9 @@
 import { useSetRecoilState } from "recoil"
 import { useMutation, useQueryClient } from "@tanstack/react-query"
-import axiosInstance from "@/utils/axiosInstance.ts"
-import { userIdState } from "@/states/auth.ts"
-import useToast from "@/hooks/useToast.ts"
-import useUserInfoQuery from "@/hooks/useUserInfoQuery.ts"
+import axiosInstance from "@/utils/axiosInstance"
+import { userIdState } from "@/states/auth"
+import useToast from "@/hooks/useToast"
+import useUserInfoQuery from "@/hooks/useUserInfoQuery"
 
 function UserInfo() {
   const setUserId = useSetRecoilState(userIdState)

--- a/chrome-extension/src/main.tsx
+++ b/chrome-extension/src/main.tsx
@@ -1,7 +1,7 @@
 import "@/styles/globals.css"
 import React from "react"
 import ReactDOM from "react-dom/client"
-import App from "@/app/App.tsx"
+import App from "@/app/App"
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/chrome-extension/tsconfig.json
+++ b/chrome-extension/tsconfig.json
@@ -11,7 +11,7 @@
     },
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
+    "allowImportingTsExtensions": false,
     "resolveJsonModule": true,
     "isolatedModules": true,
     "noEmit": true,


### PR DESCRIPTION
## 📝 Summary

<!--
PR의 주요 내용을 간단히 요약해주세요.
예: 로그인 기능에서 사용자 세션 관리 개선.
-->

vscode와 webstorm 간의 스타일 통일이 제대로 이루어지지 않고 있어 이를 수정하였습니다.

## ✅ Checklist

<!--
해당되는 항목을 [x]로 만들어주세요.
예: - [x] 관련 이슈가 명시되어 있습니다.

해당되지 않는 항목은 앞뒤로 ~를 붙여서 취소선을 그어주세요.
예: - ~[ ] 관련 이슈가 명시되어 있습니다.~
-->

- ~[ ] 관련 이슈가 명시되어 있습니다.~
- [x] 테스트가 완료되었습니다.
- ~[ ] 문서 업데이트가 포함되었습니다.~
- [x] 코드 리뷰를 위한 사전 검토를 완료했습니다.

## 📄 Description

<!--
PR의 변경 사항을 구체적으로 설명해주세요.
예: 이번 변경 사항에는 로그인 세션 시간 연장 및 오류 메시지 개선이 포함됩니다.
-->

tsconfig에서 확장자를 허용해두어 webstorm에서는 자동으로 import 구문에 확장자를 추가하였었지만, vscode에서는 확장자 없이 import하는 문제가 존재하였습니다.

이에 대한 동기화를 위해 확장자 허용을 막았고, webstorm과 vscode 모두에서 확장자를 붙이지 않게 설정을 통일하였습니다.